### PR TITLE
Fixing #102 - Poor performance on larger schemas

### DIFF
--- a/src/Renderer/minimapRenderer.ts
+++ b/src/Renderer/minimapRenderer.ts
@@ -52,6 +52,7 @@ export class MinimapRenderer {
     context.lineWidth = 1;
     context.strokeRect(minimapStartX, minimapStartY, theme.minimap.size, theme.minimap.size);
 
+    context.beginPath();
     context.rect(minimapStartX, minimapStartY, theme.minimap.size, theme.minimap.size);
     context.clip();
 


### PR DESCRIPTION
Yup, one `beginPath()` improves performance on large schemas around 4x.