### PR TITLE
Screenshot diagram function

### DIFF
--- a/src/Configuration/index.ts
+++ b/src/Configuration/index.ts
@@ -25,6 +25,8 @@ export interface DiagramOptions {
   theme: DiagramTheme;
   width: number | undefined;
   autoPanSmoothing: number;
+  screenShotMargin: number;
+  screenShotBackground: boolean;
   drawingDistance: Partial<DiagramDrawingDistanceOptions>
 }
 
@@ -39,6 +41,8 @@ const defaultOptions: DiagramOptions = {
   theme: DefaultDiagramTheme,
   width: undefined,
   autoPanSmoothing: 4.0,
+  screenShotMargin: 300,
+  screenShotBackground: false,
   drawingDistance: {
     nodeTitle: 0.0,
     nodeOptions: 0.0,

--- a/src/Diagram/index.ts
+++ b/src/Diagram/index.ts
@@ -98,7 +98,7 @@ export class Diagram {
     return { width: domElement.clientWidth, height: domElement.clientHeight };
   }
   autoResize = () => {
-    if (this.stateManager.isScreenShotInProgress) {
+    if (this.stateManager.isScreenShotInProgress()) {
       return;
     }
 

--- a/src/Diagram/stateManager/index.ts
+++ b/src/Diagram/stateManager/index.ts
@@ -63,7 +63,8 @@ export class StateManager {
         draggingElements: false,
         draggingMinimap: false,
         animatingPan: false,
-      }
+      },
+      screenShotInProgress: false,
     };
     this.htmlManager = new HtmlManager(
       this.state,
@@ -205,4 +206,10 @@ export class StateManager {
   };
   worldToScreenCoordinates = (e: ScreenPosition) =>
     this.uiManager.worldToScreen(e);
+  setScreenShotInProgress(screenShotInProgress: boolean) {
+    this.state.screenShotInProgress = screenShotInProgress;
+  }
+  isScreenShotInProgress() {
+    return this.state.screenShotInProgress;
+  }
 }

--- a/src/Events/DiagramEvents.ts
+++ b/src/Events/DiagramEvents.ts
@@ -35,6 +35,7 @@ export enum DiagramEvents {
   CenterPanRequested = "CenterPanRequested",
   MenuRequested = "MenuRequested",
   MenuItemClicked = "MenuItemClicked",
-  CenterOnNode = "CenterOnNode"
+  CenterOnNode = "CenterOnNode",
+  ScreenShotRendered = "ScreenShotRendered"
   // ...
 }

--- a/src/Models/DiagramState.ts
+++ b/src/Models/DiagramState.ts
@@ -36,4 +36,5 @@ export interface DiagramState {
   menu?: boolean;
   drawedConnection?: ScreenPosition;
   uiState: UIState;
+  screenShotInProgress: boolean;
 }

--- a/src/Renderer/ContextProvider/index.ts
+++ b/src/Renderer/ContextProvider/index.ts
@@ -1,0 +1,15 @@
+export class ContextProvider {
+  private _context: CanvasRenderingContext2D;
+
+  constructor(initialContext: CanvasRenderingContext2D) {
+    this._context = initialContext;
+  }
+
+  switchContext(context: CanvasRenderingContext2D) {
+    this._context = context;
+  }
+
+  get context() {
+    return this._context;
+  }
+}

--- a/src/Renderer/activeLinkRenderer.ts
+++ b/src/Renderer/activeLinkRenderer.ts
@@ -1,14 +1,15 @@
 import { DiagramTheme } from "../Models";
 import { ScreenPosition } from "../IO/ScreenPosition";
 import { QuadraticPath } from "./Draw/QuadraticPath";
+import { ContextProvider } from "./ContextProvider";
 export class ActiveLinkRenderer {
   constructor(
-    private context: CanvasRenderingContext2D,
+    private contextProvider: ContextProvider,
     private theme: DiagramTheme
   ) {}
   render = ({ from, to }: { from: ScreenPosition; to: ScreenPosition }) => {
     QuadraticPath(
-      this.context,
+      this.contextProvider.context,
       from.x,
       from.y,
       to.x,

--- a/src/Renderer/linkRenderer.ts
+++ b/src/Renderer/linkRenderer.ts
@@ -2,10 +2,11 @@ import { DiagramTheme, Link } from "../Models";
 import { QuadraticPath } from "./Draw/QuadraticPath";
 import { SimplifiedPath } from "./Draw/SimplifiedPath";
 import { DiagramDrawingDistanceOptions, ConfigurationManager } from "../Configuration/index";
+import { ContextProvider } from "./ContextProvider";
 export class LinkRenderer {
   distances: DiagramDrawingDistanceOptions;
   constructor(
-    private context: CanvasRenderingContext2D,
+    private contextProvider: ContextProvider,
     private theme: DiagramTheme
   ) {
     this.distances = ConfigurationManager.instance.getOption('drawingDistance') as DiagramDrawingDistanceOptions;
@@ -15,9 +16,11 @@ export class LinkRenderer {
       node: { width, height }
     } = this.theme;
 
+    const {context} = this.contextProvider;
+
     if (currentScale > this.distances.detailedLinks) {
       return QuadraticPath(
-        this.context,
+        context,
         l.o.x + width,
         l.o.y + height / 2.0,
         l.i.x,
@@ -31,7 +34,7 @@ export class LinkRenderer {
 
     if (currentScale > this.distances.simplifiedLinks) {
       return SimplifiedPath(
-        this.context,
+        context,
         l.o.x + width,
         l.o.y + height / 2.0,
         l.i.x,

--- a/src/Renderer/minimapRenderer.ts
+++ b/src/Renderer/minimapRenderer.ts
@@ -5,7 +5,7 @@ export class MinimapRenderer {
   render(context: CanvasRenderingContext2D, theme: DiagramTheme, state: DiagramState) {
     const uiState = state.uiState;
 
-    if (!uiState.minimapActive) {
+    if (!uiState.minimapActive || state.screenShotInProgress) {
       return;
     }
 

--- a/src/Renderer/nodeRenderer.ts
+++ b/src/Renderer/nodeRenderer.ts
@@ -8,11 +8,12 @@ import {
   DiagramDrawingDistanceOptions
 } from "../Configuration/index";
 import { StateManager } from "../Diagram/stateManager/index";
+import { ContextProvider } from "./ContextProvider";
 export class NodeRenderer {
   distances: DiagramDrawingDistanceOptions;
 
   constructor(
-    private context: CanvasRenderingContext2D,
+    private contextProvider: ContextProvider,
     private theme: DiagramTheme,
     private stateManager: StateManager
   ) {
@@ -239,4 +240,8 @@ export class NodeRenderer {
       });
     }
   };
+
+  get context() {
+    return this.contextProvider.context;
+  }
 }


### PR DESCRIPTION
Diagram got `screenShot()` function that returns `Promise<Blob>` with binary-encoded screenshot of entire diagram:

```
class Diagram {
/* ... */
screenShot(type: 'image/png' | 'image/jpeg' = 'image/png'): Promise<Blob>
}
```

Example use:

```
      this.diagram.screenShot('image/png').then(blob => {
        const blobDataUrl = window.URL.createObjectURL(blob);
        const aLink = document.createElement('a');
        aLink.download = 'file.png';
        aLink.href = blobDataUrl;
        aLink.click();
      })
```

Additional diagram options:
```
/* Sets margin for screenshot images (distance between node and image border) */
screenShotMargin: number; 
/* Determines if background color should be rendered in the screenshot. If set to false while using `image/png`, background will be transparent  */
screenShotBackground: boolean;
```